### PR TITLE
Coordinate grid after bed leveling is done + Marlin default baud rate

### DIFF
--- a/src/cnc/gcode/controller/AutoLevelSystem.java
+++ b/src/cnc/gcode/controller/AutoLevelSystem.java
@@ -171,7 +171,7 @@ public class AutoLevelSystem implements java.io.Serializable{
             maxPt.x - p.getX() < 0.0 || maxPt.y - p.getY() < 0.0)
            return 0.0;
 
-        //dircet hit!
+        //direct hit!
         if(Math.abs(points[p0X][p0Y].getPoint().getX() - p.getX()) < 0.00001 
                 && Math.abs(points[p0X][p0Y].getPoint().getY() - p.getY()) < 0.00001)
         {
@@ -182,11 +182,11 @@ public class AutoLevelSystem implements java.io.Serializable{
         boolean lr = p.getX() > points[p0X][p0Y].getPoint().getX(); //l=false r=true
         boolean lu = p.getY() > points[p0X][p0Y].getPoint().getY(); //l=false u=true
 
-        //calc neighbor coorinats
+        //calc neighbor coordinates
         int p1X = p0X + (lr ? 1:-1);
         int p1Y = p0Y + (lu ? 1:-1);
         
-        //Test if there exists neighbor
+        //Check if the neighbor exists
         boolean neighborX_exists = p1X < points.length && p1X >= 0;
         boolean neighborY_exists = p1Y < points[p0X].length && p1Y >= 0;
         

--- a/src/cnc/gcode/controller/AutoLevelSystem.java
+++ b/src/cnc/gcode/controller/AutoLevelSystem.java
@@ -162,6 +162,14 @@ public class AutoLevelSystem implements java.io.Serializable{
         {
             return 0.0;
         }
+        
+        // No interpolation if our point is outside the probed area 
+        Point2D.Double minPt = points[0][0].getPoint();
+        Point2D.Double maxPt = points[points.length - 1][points[points.length - 1].length - 1].getPoint();
+        
+        if (minPt.x - p.getX() > 0.0 || minPt.y - p.getY() > 0.0 ||
+            maxPt.x - p.getX() < 0.0 || maxPt.y - p.getY() < 0.0)
+           return 0.0;
 
         //dircet hit!
         if(Math.abs(points[p0X][p0Y].getPoint().getX() - p.getX()) < 0.00001 

--- a/src/cnc/gcode/controller/CNCCommand.java
+++ b/src/cnc/gcode/controller/CNCCommand.java
@@ -199,7 +199,7 @@ public class CNCCommand {
         ;
         
         /*
-         * Commands are allwoed for optimisation between the last and the first G1 move:
+         * Commands are allowed for optimisation between the last and the first G1 move:
          */
         public final static List<Type> ALLOWEDFOROPTIMISER = Collections.unmodifiableList(Arrays.asList(EMPTY, G0, G1, ARC, SPINDLEON, SPINDLEOFF, MXX, PAUSE)); 
         
@@ -442,29 +442,29 @@ public class CNCCommand {
             }
         }
         
-        //Do Nessassary Checking
+        //Do necessary checks
         switch(type)
         {
             case ARC:
                 if(p.contains('Z') || p.contains('K'))
                 {
                     state = State.ERROR;
-                    message += "ARC in Z are not Supported! ";
+                    message += "ARC in Z are not supported! ";
                 }
                 if(p.contains('P') )
                 {
                     state = State.ERROR;
-                    message += "ARC with P are not Supported! ";
+                    message += "ARC with P are not supported! ";
                 }
                 if(p.contains('R') )
                 {
                     state = State.ERROR;
-                    message += "ARC with R are not Supported! ";
+                    message += "ARC with R are not supported! ";
                 }
                 if(!p.contains('I') || !p.contains('I'))
                 {
                     state = State.ERROR;
-                    message += "ARC has to have I and J as Parameters! ";
+                    message += "ARC has to have I and J as parameters! ";
                 }
             case G0:
             case G1:
@@ -601,7 +601,7 @@ public class CNCCommand {
                         {
                             state = State.WARNING;
                         }
-                        message += "Command Without any movement! ";
+                        message += "Command without any movement! ";
                     }
                     
                     if(move.s[2] != move.e[2] && Double.isNaN(move.e[2]) == false)
@@ -813,7 +813,7 @@ public class CNCCommand {
                 }
                 
                 //Correct Backlash  (http://forums.reprap.org/read.php?154,178612 thanks to georgeflug)
-                boolean[] direction = cin.lastmovedirection.clone(); //fase positive true negative
+                boolean[] direction = cin.lastmovedirection.clone(); //false positive true negative
                 ArrayList<Move> newmoves = new ArrayList<>(moves.length);
                 for(Move move:moves)
                 {

--- a/src/cnc/gcode/controller/JPanelAutoLevel.java
+++ b/src/cnc/gcode/controller/JPanelAutoLevel.java
@@ -137,22 +137,6 @@ public class JPanelAutoLevel extends javax.swing.JPanel implements IGUIEvent {
                 g2.setColor(new Color(Integer.parseInt(DatabaseV2.CBACKGROUND.get())));
                 g2.fill(new Rectangle2D.Double(0, 0, ariawidth, ariaheight));
 
-                //Draw Koardinates
-                if(DatabaseV2.CGRIDDISTANCE.getsaved()>0){
-                    g2.setColor(new Color(Integer.parseInt(DatabaseV2.CGRID.get())));
-
-                    g2.setStroke(new BasicStroke((float)(1/scalex)));
-                    for(int x=1;x<ariawidth/DatabaseV2.CGRIDDISTANCE.getsaved();x++){
-                        g2.drawLine((int)(x*DatabaseV2.CGRIDDISTANCE.getsaved()),0,(int)(x*DatabaseV2.CGRIDDISTANCE.getsaved()), (int)(ariaheight));
-                    }
-
-                    g2.setStroke(new BasicStroke((float)(1/scaley)));
-                    for(int y=1;y<ariaheight/DatabaseV2.CGRIDDISTANCE.getsaved();y++){
-                        g2.drawLine(0,(int)(y*DatabaseV2.CGRIDDISTANCE.getsaved()),(int)(ariawidth),(int)(y*DatabaseV2.CGRIDDISTANCE.getsaved()));
-                    }
-                }
-                
-                
                 try {
                     AffineTransform t = g2.getTransform();
                     t.invert();
@@ -228,6 +212,9 @@ public class JPanelAutoLevel extends javax.swing.JPanel implements IGUIEvent {
                                     90,
                                     zh - 4);
                     }
+                    
+                    g2.translate(rect.x, rect.y);
+                    g2.scale(scalex, scaley);
                 }
                 else
                 {
@@ -246,6 +233,22 @@ public class JPanelAutoLevel extends javax.swing.JPanel implements IGUIEvent {
 
                     }
                 }
+                
+                //Draw coordinate plane
+                if(DatabaseV2.CGRIDDISTANCE.getsaved()>0){
+                    g2.setColor(new Color(Integer.parseInt(DatabaseV2.CGRID.get())));
+
+                    g2.setStroke(new BasicStroke((float)(1/scalex)));
+                    for(int x=1;x<ariawidth/DatabaseV2.CGRIDDISTANCE.getsaved();x++){
+                        g2.drawLine((int)(x*DatabaseV2.CGRIDDISTANCE.getsaved()),0,(int)(x*DatabaseV2.CGRIDDISTANCE.getsaved()), (int)(ariaheight));
+                    }
+
+                    g2.setStroke(new BasicStroke((float)(1/scaley)));
+                    for(int y=1;y<ariaheight/DatabaseV2.CGRIDDISTANCE.getsaved();y++){
+                        g2.drawLine(0,(int)(y*DatabaseV2.CGRIDDISTANCE.getsaved()),(int)(ariawidth),(int)(y*DatabaseV2.CGRIDDISTANCE.getsaved()));
+                    }
+                }
+                
                 return image;
             }
 

--- a/src/cnc/gcode/controller/communication/ComCoreJSSC.java
+++ b/src/cnc/gcode/controller/communication/ComCoreJSSC.java
@@ -129,6 +129,6 @@ class ComCoreJSSC extends AComCore {
         return new ArrayList<String>(Arrays.asList(SerialPortList.getPortNames())); 
     }
     public static ArrayList<Integer> getPortsSpeeds(){
-        return new ArrayList<Integer>(Arrays.asList(new Integer[]{110,300,600,1200,4800,9600,14400,19200,38400,57600,115200,128000,256000}));
+        return new ArrayList<Integer>(Arrays.asList(new Integer[]{110,300,600,1200,4800,9600,14400,19200,38400,57600,115200,128000,250000,256000}));
     }
 }

--- a/src/cnc/gcode/controller/communication/ComCoreJSSC.java
+++ b/src/cnc/gcode/controller/communication/ComCoreJSSC.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 import jssc.SerialPort;
 import jssc.SerialPortList;
 
-//Core for kommunikation
+//Core for communication
 
 class ComCoreJSSC extends AComCore {
     private final SerialPort serialPort;
@@ -37,7 +37,7 @@ class ComCoreJSSC extends AComCore {
         }
         if (!serialPort.setParams(speed,SerialPort.DATABITS_8,SerialPort.STOPBITS_1,SerialPort.PARITY_NONE))
         {
-            throw new Exception("Cannot set Parameters for selected port!");
+            throw new Exception("Cannot set parameters for selected port!");
         }
         
         receiveTimer = new Timer() {


### PR DESCRIPTION
This change makes the coordinate plane appear after bed leveling is done. I have also added the default baud rate for Marlin to the dropdown menu (Perhaps it's better to change that to a number field with dropdown menu in the future?)

![2015-04-15 10_26_09-cnc-gcode-controller - netbeans ide 8 0 2](https://cloud.githubusercontent.com/assets/6731717/7154968/3012ac14-e35b-11e4-910e-e493b8fef6cc.png)
